### PR TITLE
Fixed resolver-config.xml Deps Loading

### DIFF
--- a/config/studio/dependency/resolver-config.xml
+++ b/config/studio/dependency/resolver-config.xml
@@ -75,6 +75,95 @@
                 </dependency-type>
             </dependency-types>
         </item-type>
+      <item-type>
+            <!-- name of type -->
+            <name>top-level-cabinets</name>
+            <!-- how to identify items of this type -->
+            <includes>
+                <!-- path pattern regexes (multiple) -->
+                <path-pattern>/site/origins/.*\.xml</path-pattern>
+                <path-pattern>/site/streams/.*\.xml</path-pattern>
+                <path-pattern>/site/taxonomies/.*\.xml</path-pattern>
+                <path-pattern>/site/videos/.*\.xml</path-pattern>
+            </includes>
+            <!-- how to find dependencies in these items -->
+            <dependency-types>
+                <dependency-type>
+                    <name>page</name>
+                    <includes>
+                        <pattern>
+                            <find-regex>/site/website/([^&lt;]+)\.xml</find-regex>
+                        </pattern>
+                    </includes>
+                </dependency-type>
+                <dependency-type>
+                    <name>component</name>
+                    <includes>
+                        <pattern>
+                            <find-regex>/site/origins/([^&lt;]+)\.xml</find-regex>
+                        </pattern>
+                        <pattern>
+                            <find-regex>/site/streams/([^&lt;]+)\.xml</find-regex>
+                        </pattern>
+                        <pattern>
+                            <find-regex>/site/taxonomies/([^&lt;]+)\.xml</find-regex>
+                        </pattern>
+                        <pattern>
+                            <find-regex>/site/videos/([^&lt;]+)\.xml</find-regex>
+                        </pattern>
+                        <pattern>
+                            <find-regex>/site/components/([^&lt;]+)\.xml</find-regex>
+                        </pattern>
+                        <pattern>
+                            <find-regex>/site/system/page-components/([^&lt;]+)\.xml</find-regex>
+                        </pattern>
+                        <pattern>
+                            <find-regex>/site/component-bindings/([^&lt;]+)\.xml</find-regex>
+                        </pattern>
+                        <pattern>
+                            <find-regex>/site/indexes/([^&lt;]+)\.xml</find-regex>
+                        </pattern>
+                        <pattern>
+                            <find-regex>/site/resources/([^&lt;]+)\.xml</find-regex>
+                        </pattern>
+                    </includes>
+                </dependency-type>
+                <dependency-type>
+                    <name>asset</name>
+                    <includes>
+                        <!-- path patterns to look for (multiple) -->
+                        <pattern>
+                            <find-regex>/static-assets/([^&lt;"'\)]+)</find-regex>
+                        </pattern>
+                    </includes>
+                </dependency-type>
+                <dependency-type>
+                    <name>rendering-template</name>
+                    <includes>
+                        <pattern>
+                            <find-regex>/templates/([^&lt;"]+)\.ftl</find-regex>
+                        </pattern>
+                    </includes>
+                </dependency-type>
+                <dependency-type>
+                    <name>script</name>
+                    <includes>
+                        <pattern>
+                            <find-regex>/scripts/([^&lt;"]+)\.groovy</find-regex>
+                        </pattern>
+                        <pattern>
+                            <find-regex>&lt;content-type&gt;/(.*)/(.*)&lt;/content-type&gt;</find-regex>
+                            <transforms>
+                                <transform>
+                                    <match>&lt;content-type&gt;/(.*)/(.*)&lt;/content-type&gt;</match>
+                                    <replace>/scripts/$1s/$2.groovy</replace>
+                                </transform>
+                            </transforms>
+                        </pattern>
+                    </includes>
+                </dependency-type>
+            </dependency-types>
+        </item-type>
         <item-type>
             <!-- name of type -->
             <name>component</name>

--- a/config/studio/dependency/resolver-config.xml
+++ b/config/studio/dependency/resolver-config.xml
@@ -39,92 +39,11 @@
                         </pattern>
                     </includes>
                 </dependency-type>
-                <dependency-type>
-                    <name>asset</name>
-                    <includes>
-                        <!-- path patterns to look for (multiple) -->
-                        <pattern>
-                            <find-regex>/static-assets/([^&lt;"'\)]+)</find-regex>
-                        </pattern>
-                    </includes>
-                </dependency-type>
-                <dependency-type>
-                    <name>rendering-template</name>
+		<dependency-type>
+                    <name>item</name>
                     <includes>
                         <pattern>
-                            <find-regex>/templates/([^&lt;"]+)\.ftl</find-regex>
-                        </pattern>
-                    </includes>
-                </dependency-type>
-                <dependency-type>
-                    <name>script</name>
-                    <includes>
-                        <pattern>
-                            <find-regex>/scripts/([^&lt;"]+)\.groovy</find-regex>
-                        </pattern>
-                        <pattern>
-                            <find-regex>&lt;content-type&gt;/(.*)/(.*)&lt;/content-type&gt;</find-regex>
-                            <transforms>
-                                <transform>
-                                    <match>&lt;content-type&gt;/(.*)/(.*)&lt;/content-type&gt;</match>
-                                    <replace>/scripts/$1s/$2.groovy</replace>
-                                </transform>
-                            </transforms>
-                        </pattern>
-                    </includes>
-                </dependency-type>
-            </dependency-types>
-        </item-type>
-      <item-type>
-            <!-- name of type -->
-            <name>top-level-cabinets</name>
-            <!-- how to identify items of this type -->
-            <includes>
-                <!-- path pattern regexes (multiple) -->
-                <path-pattern>/site/origins/.*\.xml</path-pattern>
-                <path-pattern>/site/streams/.*\.xml</path-pattern>
-                <path-pattern>/site/taxonomies/.*\.xml</path-pattern>
-                <path-pattern>/site/videos/.*\.xml</path-pattern>
-            </includes>
-            <!-- how to find dependencies in these items -->
-            <dependency-types>
-                <dependency-type>
-                    <name>page</name>
-                    <includes>
-                        <pattern>
-                            <find-regex>/site/website/([^&lt;]+)\.xml</find-regex>
-                        </pattern>
-                    </includes>
-                </dependency-type>
-                <dependency-type>
-                    <name>component</name>
-                    <includes>
-                        <pattern>
-                            <find-regex>/site/origins/([^&lt;]+)\.xml</find-regex>
-                        </pattern>
-                        <pattern>
-                            <find-regex>/site/streams/([^&lt;]+)\.xml</find-regex>
-                        </pattern>
-                        <pattern>
-                            <find-regex>/site/taxonomies/([^&lt;]+)\.xml</find-regex>
-                        </pattern>
-                        <pattern>
-                            <find-regex>/site/videos/([^&lt;]+)\.xml</find-regex>
-                        </pattern>
-                        <pattern>
-                            <find-regex>/site/components/([^&lt;]+)\.xml</find-regex>
-                        </pattern>
-                        <pattern>
-                            <find-regex>/site/system/page-components/([^&lt;]+)\.xml</find-regex>
-                        </pattern>
-                        <pattern>
-                            <find-regex>/site/component-bindings/([^&lt;]+)\.xml</find-regex>
-                        </pattern>
-                        <pattern>
-                            <find-regex>/site/indexes/([^&lt;]+)\.xml</find-regex>
-                        </pattern>
-                        <pattern>
-                            <find-regex>/site/resources/([^&lt;]+)\.xml</find-regex>
+                            <find-regex>/site/(?!website/|components/)([^&lt;]+)\.xml</find-regex>
                         </pattern>
                     </includes>
                 </dependency-type>
@@ -203,6 +122,96 @@
                         </pattern>
                         <pattern>
                             <find-regex>/site/resources/([^&lt;]+)\.xml</find-regex>
+                        </pattern>
+                    </includes>
+                </dependency-type>
+		<dependency-type>
+                    <name>item</name>
+                    <includes>
+                        <pattern>
+                            <find-regex>/site/(?!website/|components/)([^&lt;]+)\.xml</find-regex>
+                        </pattern>
+                    </includes>
+                </dependency-type>
+                <dependency-type>
+                    <name>asset</name>
+                    <includes>
+                        <!-- path patterns to look for (multiple) -->
+                        <pattern>
+                            <find-regex>/static-assets/([^&lt;"'\)]+)</find-regex>
+                        </pattern>
+                    </includes>
+                </dependency-type>
+                <dependency-type>
+                    <name>rendering-template</name>
+                    <includes>
+                        <pattern>
+                            <find-regex>/templates/([^&lt;"]+)\.ftl</find-regex>
+                        </pattern>
+                    </includes>
+                </dependency-type>
+                <dependency-type>
+                    <name>script</name>
+                    <includes>
+                        <pattern>
+                            <find-regex>/scripts/([^&lt;"]+)\.groovy</find-regex>
+                        </pattern>
+                        <pattern>
+                            <find-regex>&lt;content-type&gt;/(.*)/(.*)&lt;/content-type&gt;</find-regex>
+                            <transforms>
+                                <transform>
+                                    <match>&lt;content-type&gt;/(.*)/(.*)&lt;/content-type&gt;</match>
+                                    <replace>/scripts/$1s/$2.groovy</replace>
+                                </transform>
+                            </transforms>
+                        </pattern>
+                    </includes>
+                </dependency-type>
+            </dependency-types>
+        </item-type>
+	<item-type>
+            <!-- an item is content that is not a page nor a component -->
+            <name>item</name>
+            <!-- how to identify items of this type -->
+            <includes>
+                <!-- path pattern regexes (multiple) -->
+                <path-pattern>/site/(?!website/|components/).*\.xml</path-pattern>
+            </includes>
+            <!-- how to find dependencies in these items -->
+            <dependency-types>
+                <dependency-type>
+                    <name>page</name>
+                    <includes>
+                        <pattern>
+                            <find-regex>/site/website/([^&lt;]+)\.xml</find-regex>
+                        </pattern>
+                    </includes>
+                </dependency-type>
+                <dependency-type>
+                    <name>component</name>
+                    <includes>
+                        <pattern>
+                            <find-regex>/site/components/([^&lt;]+)\.xml</find-regex>
+                        </pattern>
+                        <pattern>
+                            <find-regex>/site/system/page-components/([^&lt;]+)\.xml</find-regex>
+                        </pattern>
+                        <pattern>
+                            <find-regex>/site/component-bindings/([^&lt;]+)\.xml</find-regex>
+                        </pattern>
+                        <pattern>
+                            <find-regex>/site/indexes/([^&lt;]+)\.xml</find-regex>
+                        </pattern>
+                        <pattern>
+                            <find-regex>/site/resources/([^&lt;]+)\.xml</find-regex>
+                        </pattern>
+                    </includes>
+                </dependency-type>
+		<dependency-type>
+                    <name>item</name>
+                    <includes>
+                        <pattern>
+                            <find-regex>/site/(?!website/|components/)([^&lt;]+)\.xml</find-regex>
                         </pattern>
                     </includes>
                 </dependency-type>


### PR DESCRIPTION
Follow up from a support call with @russdanner to properly map dependencies when top level cabinets are used.