### PR TITLE
 #3271

### DIFF
--- a/config/studio/site-config.xml
+++ b/config/studio/site-config.xml
@@ -40,6 +40,10 @@
         <live-environment>live</live-environment>
     </published-repository>
 
+    <form-engine>
+        <field-name-postfix>true</field-name-postfix>
+    </form-engine>
+
     <!--
         Pattern that Studio will use to load plugin from the site repository
         Required placeholders: ${type}, ${name}


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/3271 - [studio] Default site blueprints should enforce postfixes by default and have all content type fields with postfixes #3271